### PR TITLE
session, sessionctx: support encoding user vars

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -234,7 +234,7 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowPlacementForPartition:
 		return e.fetchShowPlacementForPartition(ctx)
 	case ast.ShowSessionStates:
-		return e.fetchShowSessionStates(ctx)
+		return e.fetchShowSessionStates()
 	}
 	return nil
 }
@@ -1893,7 +1893,17 @@ func (e *ShowExec) fetchShowBuiltins() error {
 	return nil
 }
 
-func (e *ShowExec) fetchShowSessionStates(ctx context.Context) error {
+func (e *ShowExec) fetchShowSessionStates() error {
+	data, err := e.ctx.EncodeSessionStates()
+	if err != nil {
+		return err
+	}
+	valuesJSON := json.BinaryJSON{}
+	err = valuesJSON.UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+	e.appendRow([]interface{}{valuesJSON})
 	return nil
 }
 

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -146,7 +146,7 @@ func (e *SimpleExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	case *ast.SetPwdStmt:
 		err = e.executeSetPwd(ctx, x)
 	case *ast.SetSessionStatesStmt:
-		err = e.executeSetSessionStates(ctx, x)
+		err = e.executeSetSessionStates(x)
 	case *ast.KillStmt:
 		err = e.executeKillStmt(ctx, x)
 	case *ast.BinlogStmt:
@@ -1657,8 +1657,8 @@ func asyncDelayShutdown(p *os.Process, delay time.Duration) {
 	}
 }
 
-func (e *SimpleExec) executeSetSessionStates(ctx context.Context, s *ast.SetSessionStatesStmt) error {
-	return nil
+func (e *SimpleExec) executeSetSessionStates(s *ast.SetSessionStatesStmt) error {
+	return e.ctx.DecodeSessionStates([]byte(s.SessionStates))
 }
 
 func (e *SimpleExec) executeAdmin(s *ast.AdminStmt) error {

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -425,9 +425,9 @@ func (s SessionInfo) String() string {
 
 // TableLockTpInfo is composed by schema ID, table ID and table lock type.
 type TableLockTpInfo struct {
-	SchemaID int64
-	TableID  int64
-	Tp       TableLockType
+	SchemaID int64         `json:"schema-id"`
+	TableID  int64         `json:"table-id"`
+	Tp       TableLockType `json:"tp"`
 }
 
 // TableLockState is the state for table lock.

--- a/parser/types/field_type.go
+++ b/parser/types/field_type.go
@@ -38,14 +38,14 @@ var (
 
 // FieldType records field type information.
 type FieldType struct {
-	Tp      byte
-	Flag    uint
-	Flen    int
-	Decimal int
-	Charset string
-	Collate string
+	Tp      byte   `json:"tp,omitempty"`
+	Flag    uint   `json:"flag,omitempty"`
+	Flen    int    `json:"flen,omitempty"`
+	Decimal int    `json:"decimal,omitempty"`
+	Charset string `json:"charset,omitempty"`
+	Collate string `json:"collate,omitempty"`
 	// Elems is the element list for enum and set type.
-	Elems []string
+	Elems []string `json:"elems,omitempty"`
 }
 
 // NewFieldType returns a FieldType,

--- a/session/session.go
+++ b/session/session.go
@@ -78,6 +78,7 @@ import (
 	"github.com/pingcap/tidb/session/txninfo"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
@@ -168,6 +169,9 @@ type Session interface {
 	SetDiskFullOpt(level kvrpcpb.DiskFullOpt)
 	GetDiskFullOpt() kvrpcpb.DiskFullOpt
 	ClearDiskFullOpt()
+
+	EncodeSessionStates() ([]byte, error)
+	DecodeSessionStates([]byte) error
 }
 
 var _ Session = (*session)(nil)
@@ -3437,4 +3441,37 @@ func (s *session) getSnapshotInterceptor() kv.SnapshotInterceptor {
 
 func (s *session) GetStmtStats() *stmtstats.StatementStats {
 	return s.stmtStats
+}
+
+func (s *session) EncodeSessionStates() ([]byte, error) {
+	s.txn.mu.Lock()
+	if s.txn.Valid() {
+		s.txn.mu.Unlock()
+		return nil, errors.New("session is in a transaction")
+	}
+	s.txn.mu.Unlock()
+
+	sessionStates := &session_states.SessionStates{}
+	err := s.sessionVars.EncodeSessionStates(sessionStates)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionStates.LockedTables = s.lockedTables
+	result, err := json.Marshal(sessionStates)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return result, nil
+}
+
+func (s *session) DecodeSessionStates(data []byte) error {
+	var sessionStates session_states.SessionStates
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&sessionStates); err != nil {
+		return errors.Trace(err)
+	}
+	s.lockedTables = sessionStates.LockedTables
+	return s.sessionVars.DecodeSessionStates(&sessionStates)
 }

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -148,6 +148,10 @@ type Context interface {
 	GetStmtStats() *stmtstats.StatementStats
 	// ShowProcess returns ProcessInfo running in current Context
 	ShowProcess() *util.ProcessInfo
+	// EncodeSessionStates encodes session states into a JSON.
+	EncodeSessionStates() ([]byte, error)
+	// DecodeSessionStates decodes a map into session states.
+	DecodeSessionStates([]byte) error
 }
 
 type basicCtxType int

--- a/sessionctx/session_states/session_states.go
+++ b/sessionctx/session_states/session_states.go
@@ -1,0 +1,78 @@
+package session_states
+
+import (
+	"time"
+
+	"github.com/pingcap/tidb/parser/model"
+	ptypes "github.com/pingcap/tidb/parser/types"
+	"github.com/pingcap/tidb/types"
+)
+
+type TxnIsolationLevelOneShot struct {
+	State uint   `json:"state"`
+	Value string `json:"value"`
+}
+
+type SQLWarn struct {
+	Level   string `json:"level"`
+	Code    uint16 `json:"code"`
+	Message string `json:"message"`
+}
+
+type SessionStates struct {
+	LockedTables         map[int64]model.TableLockTpInfo `json:"locked-tables,omitempty"`
+	UserVars             map[string]types.DatumJSON      `json:"user-vars,omitempty"`
+	UserVarTypes         map[string]*ptypes.FieldType    `json:"user-var-types,omitempty"`
+	SystemVars           map[string]string               `json:"system-vars,omitempty"`
+	PreparedStmts        map[uint32]interface{}          `json:"prepared-stmts,omitempty"`
+	PreparedStmtNameToID map[string]uint32               `json:"prepared-stmt-names,omitempty"`
+	PreparedStmtID       uint32                          `json:"prepared-stmt-id,omitempty"`
+	TxnIsolationLevel    *TxnIsolationLevelOneShot       `json:"txn_iso_level,omitempty"`
+	Status               uint16                          `json:"status,omitempty"`
+	CurrentDB            string                          `json:"current-db,omitempty"`
+	LastFoundRows        uint64                          `json:"last-found-rows,omitempty"`
+	LastInsertID         uint64                          `json:"last-insert-id,omitempty"`
+	PrevAffectedRows     int64                           `json:"affected-rows,omitempty"`
+	SequenceLatestValues map[int64]int64                 `json:"sequence-values,omitempty"`
+	MPPStoreLastFailTime map[string]time.Time            `json:"store-last-fail,omitempty"`
+	Warnings             []SQLWarn                       `json:"warnings,omitempty"`
+}
+
+func (ss *SessionStates) DecodeUserVars() (map[string]types.Datum, error) {
+	result := make(map[string]types.Datum, len(ss.UserVars))
+	for name, datumJson := range ss.UserVars {
+		datum, err := types.DatumJSONToDatum(&datumJson)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = *datum
+	}
+	return result, nil
+}
+
+func (ss *SessionStates) EncodeUserVars(userVars map[string]types.Datum) error {
+	ss.UserVars = make(map[string]types.DatumJSON, len(userVars))
+	for name, datum := range userVars {
+		datumJson, err := types.DatumToDatumJSON(&datum)
+		if err != nil {
+			return err
+		}
+		ss.UserVars[name] = *datumJson
+	}
+	return nil
+}
+
+func (ss *SessionStates) DecodeUserVarFields() map[string]*ptypes.FieldType {
+	result := make(map[string]*ptypes.FieldType, len(ss.UserVarTypes))
+	for name, userVar := range ss.UserVarTypes {
+		result[name] = userVar.Clone()
+	}
+	return result
+}
+
+func (ss *SessionStates) EncodeUserVarFields(userVarFields map[string]*ptypes.FieldType) {
+	ss.UserVarTypes = make(map[string]*ptypes.FieldType, len(userVarFields))
+	for name, userVar := range userVarFields {
+		ss.UserVarTypes[name] = userVar.Clone()
+	}
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	pumpcli "github.com/pingcap/tidb/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/types"
@@ -1680,6 +1681,40 @@ func (s *SessionVars) GetTemporaryTable(tblInfo *model.TableInfo) tableutil.Temp
 		return tempTable
 	}
 
+	return nil
+}
+
+// EncodeSessionStates saves session states into SessionStates.
+func (s *SessionVars) EncodeSessionStates(sessionStates *session_states.SessionStates) error {
+	var err error
+	func() {
+		s.UsersLock.RLock()
+		defer s.UsersLock.RUnlock()
+		if err = sessionStates.EncodeUserVars(s.Users); err != nil {
+			return
+		}
+		sessionStates.EncodeUserVarFields(s.UserVarTypes)
+	}()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DecodeSessionStates restore session states from SessionStates.
+func (s *SessionVars) DecodeSessionStates(sessionStates *session_states.SessionStates) error {
+	var err error
+	func() {
+		s.UsersLock.Lock()
+		defer s.UsersLock.Unlock()
+		if s.Users, err = sessionStates.DecodeUserVars(); err != nil {
+			return
+		}
+		s.UserVarTypes = sessionStates.DecodeUserVarFields()
+	}()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/types/datum.go
+++ b/types/datum.go
@@ -2416,3 +2416,68 @@ func EstimatedMemUsage(array []Datum, numOfRows int) int64 {
 	bytesConsumed += len(array) * sizeOfEmptyDatum
 	return int64(bytesConsumed * numOfRows)
 }
+
+type DatumJSON struct {
+	K         byte      `json:"k"`
+	Decimal   uint16    `json:"decimal,omitempty"`
+	Length    uint32    `json:"length,omitempty"`
+	I         int64     `json:"i,omitempty"`
+	Collation string    `json:"collation,omitempty"`
+	B         []byte    `json:"b,omitempty"`
+	Duration  *Duration `json:"d,omitempty"`
+	U         uint64    `json:"u,omitempty"`
+	F         float64   `json:"f,omitempty"`
+}
+
+func DatumToDatumJSON(datum *Datum) (*DatumJSON, error) {
+	datumJson := &DatumJSON{
+		K:         datum.k,
+		Decimal:   datum.decimal,
+		Length:    datum.length,
+		I:         datum.i,
+		Collation: datum.collation,
+		B:         datum.b,
+	}
+	var err error
+	switch datum.k {
+	case KindMysqlTime:
+		datumJson.U, err = datum.GetMysqlTime().ToPackedUint()
+	case KindMysqlDecimal:
+		datumJson.F, err = datum.GetMysqlDecimal().ToFloat64()
+	case KindMysqlDuration:
+		d := datum.GetMysqlDuration()
+		datumJson.Duration = &d
+	default:
+		if datum.x != nil {
+			return nil, errors.New(fmt.Sprintf("unsupported type: %d", datum.k))
+		}
+	}
+	return datumJson, err
+}
+
+func DatumJSONToDatum(datumJson *DatumJSON) (*Datum, error) {
+	datum := &Datum{
+		k:         datumJson.K,
+		decimal:   datumJson.Decimal,
+		length:    datumJson.Length,
+		i:         datumJson.I,
+		collation: datumJson.Collation,
+		b:         datumJson.B,
+	}
+	var err error
+	switch datumJson.K {
+	case KindMysqlTime:
+		var t Time
+		if err = t.FromPackedUint(datumJson.U); err == nil {
+			datum.SetMysqlTime(t)
+		}
+	case KindMysqlDecimal:
+		var d MyDecimal
+		if err = d.FromFloat64(datumJson.F); err == nil {
+			datum.SetMysqlDecimal(&d)
+		}
+	case KindMysqlDuration:
+		datum.SetMysqlDuration(*datumJson.Duration)
+	}
+	return datum, err
+}

--- a/types/time.go
+++ b/types/time.go
@@ -1280,10 +1280,10 @@ func NewDuration(hour, minute, second, microsecond int, fsp int) Duration {
 
 // Duration is the type for MySQL TIME type.
 type Duration struct {
-	gotime.Duration
+	gotime.Duration `json:"duration"`
 	// Fsp is short for Fractional Seconds Precision.
 	// See http://dev.mysql.com/doc/refman/5.7/en/fractional-seconds.html
-	Fsp int
+	Fsp int `json:"fsp"`
 }
 
 // MaxMySQLDuration returns Duration with maximum mysql time.

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -108,6 +108,16 @@ func (c *Context) ShowProcess() *util.ProcessInfo {
 	return &util.ProcessInfo{}
 }
 
+// EncodeSessionStates implements sessionctx.Context EncodeSessionStates interface.
+func (c *Context) EncodeSessionStates() ([]byte, error) {
+	return nil, errors.Errorf("Not Supported")
+}
+
+// DecodeSessionStates implements sessionctx.Context DecodeSessionStates interface.
+func (c *Context) DecodeSessionStates([]byte) error {
+	return errors.Errorf("Not Supported")
+}
+
 type mockDDLOwnerChecker struct{}
 
 func (c *mockDDLOwnerChecker) IsOwner() bool { return true }


### PR DESCRIPTION
This PR encodes user variables and locked tables into JSON and decodes JSON to these variables.

Example:
```sql
mysql> set @y=now();
Query OK, 0 rows affected (0.00 sec)

mysql> select @y;
+---------------------+
| @y                  |
+---------------------+
| 2022-04-09 14:35:38 |
+---------------------+
1 row in set (0.00 sec)

mysql> show session_states;                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Session_states                                                                                                                                                    |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| {"user-var-types": {"y": {"charset": "binary", "collate": "binary", "flag": 129, "flen": 19, "tp": 12}}, "user-vars": {"y": {"k": 13, "u": 1850015075931258880}}} |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> set @y=now();
Query OK, 0 rows affected (0.00 sec)

mysql> select @y;
+---------------------+
| @y                  |
+---------------------+
| 2022-04-09 14:35:53 |
+---------------------+
1 row in set (0.00 sec)

mysql> set session_states '{"user-var-types": {"y": {"charset": "binary", "collate": "binary", "flag": 129, "flen": 19, "tp": 12}}, "user-vars": {"y": {"k": 13, "u": 1850015075931258880}}}';
Query OK, 0 rows affected (0.00 sec)

mysql> select @y;                                                                                                                                             
+---------------------+
| @y                  |
+---------------------+
| 2022-04-09 14:35:38 |
+---------------------+
1 row in set (0.00 sec)
```

Why I do not use `select @x` and `set @x`:
- The accurate type and charset of `@x` can not be fetched through `select @x`.
- It still needs a way to fetch the names of all the user variables, which can not be fetched through any existing statements.