### PR TITLE
server, session: support encoding and decoding prepared statements

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/helper"
@@ -234,7 +235,7 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowPlacementForPartition:
 		return e.fetchShowPlacementForPartition(ctx)
 	case ast.ShowSessionStates:
-		return e.fetchShowSessionStates()
+		return e.fetchShowSessionStates(ctx)
 	}
 	return nil
 }
@@ -1893,14 +1894,18 @@ func (e *ShowExec) fetchShowBuiltins() error {
 	return nil
 }
 
-func (e *ShowExec) fetchShowSessionStates() error {
-	data, err := e.ctx.EncodeSessionStates()
+func (e *ShowExec) fetchShowSessionStates(ctx context.Context) error {
+	sessionStates := &session_states.SessionStates{}
+	err := e.ctx.EncodeSessionStates(ctx, sessionStates)
 	if err != nil {
 		return err
 	}
-	valuesJSON := json.BinaryJSON{}
-	err = valuesJSON.UnmarshalJSON(data)
+	data, err := gjson.Marshal(sessionStates)
 	if err != nil {
+		return errors.Trace(err)
+	}
+	valuesJSON := json.BinaryJSON{}
+	if err = valuesJSON.UnmarshalJSON(data); err != nil {
 		return err
 	}
 	e.appendRow([]interface{}{valuesJSON})

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -15,7 +15,9 @@
 package executor
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -41,6 +43,7 @@ import (
 	"github.com/pingcap/tidb/plugin"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
@@ -146,7 +149,7 @@ func (e *SimpleExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	case *ast.SetPwdStmt:
 		err = e.executeSetPwd(ctx, x)
 	case *ast.SetSessionStatesStmt:
-		err = e.executeSetSessionStates(x)
+		err = e.executeSetSessionStates(ctx, x)
 	case *ast.KillStmt:
 		err = e.executeKillStmt(ctx, x)
 	case *ast.BinlogStmt:
@@ -1657,8 +1660,14 @@ func asyncDelayShutdown(p *os.Process, delay time.Duration) {
 	}
 }
 
-func (e *SimpleExec) executeSetSessionStates(s *ast.SetSessionStatesStmt) error {
-	return e.ctx.DecodeSessionStates([]byte(s.SessionStates))
+func (e *SimpleExec) executeSetSessionStates(ctx context.Context, s *ast.SetSessionStatesStmt) error {
+	var sessionStates session_states.SessionStates
+	decoder := json.NewDecoder(bytes.NewReader([]byte(s.SessionStates)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&sessionStates); err != nil {
+		return errors.Trace(err)
+	}
+	return e.ctx.DecodeSessionStates(ctx, &sessionStates)
 }
 
 func (e *SimpleExec) executeAdmin(s *ast.AdminStmt) error {

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -17,6 +17,9 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"github.com/pingcap/tidb/sessionctx/session_states"
+	"strings"
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
@@ -50,8 +53,7 @@ func NewTiDBDriver(store kv.Storage) *TiDBDriver {
 // TiDBContext implements QueryCtx.
 type TiDBContext struct {
 	session.Session
-	currentDB string
-	stmts     map[int]*TiDBStatement
+	stmts map[int]*TiDBStatement
 }
 
 // TiDBStatement implements PreparedStatement.
@@ -197,21 +199,16 @@ func (qd *TiDBDriver) OpenCtx(connID uint64, capability uint32, collation uint8,
 	se.SetClientCapability(capability)
 	se.SetConnectionID(connID)
 	tc := &TiDBContext{
-		Session:   se,
-		currentDB: dbname,
-		stmts:     make(map[int]*TiDBStatement),
+		Session: se,
+		stmts:   make(map[int]*TiDBStatement),
 	}
+	se.SetPreparedStmtsStatesHandler(tc)
 	return tc, nil
 }
 
 // GetWarnings implements QueryCtx GetWarnings method.
 func (tc *TiDBContext) GetWarnings() []stmtctx.SQLWarn {
 	return tc.GetSessionVars().StmtCtx.GetWarnings()
-}
-
-// CurrentDB implements QueryCtx CurrentDB method.
-func (tc *TiDBContext) CurrentDB() string {
-	return tc.currentDB
 }
 
 // WarningCount implements QueryCtx WarningCount method.
@@ -298,6 +295,67 @@ func (tc *TiDBContext) Prepare(sql string) (statement PreparedStatement, columns
 // GetStmtStats implements the sessionctx.Context interface.
 func (tc *TiDBContext) GetStmtStats() *stmtstats.StatementStats {
 	return tc.Session.GetStmtStats()
+}
+
+// EncodeSessionStates implements SessionStatesHandler EncodeSessionStates interface.
+func (tc *TiDBContext) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
+	sessionVars := tc.Session.GetSessionVars()
+	sessionStates.PreparedStmts = make(map[uint32]*session_states.PreparedStmtInfo, len(sessionVars.PreparedStmts))
+	for preparedID, preparedObj := range sessionVars.PreparedStmts {
+		preparedStmt, ok := preparedObj.(*core.CachedPrepareStmt)
+		if !ok {
+			// impossible here
+			return errors.Errorf("invalid CachedPrepareStmt type")
+		}
+		sessionStates.PreparedStmts[preparedID] = &session_states.PreparedStmtInfo{
+			StmtText: preparedStmt.StmtText,
+			StmtDB:   preparedStmt.StmtDB,
+		}
+	}
+	for name, id := range sessionVars.PreparedStmtNameToID {
+		// Binary protocol statements do not have names.
+		if preparedStmtInfo, ok := sessionStates.PreparedStmts[id]; ok {
+			preparedStmtInfo.Name = name
+		}
+	}
+	for id, stmt := range tc.stmts {
+		preparedStmtInfo, ok := sessionStates.PreparedStmts[uint32(id)]
+		if !ok {
+			// impossible here
+			return errors.Errorf("prepared statement %d not found", id)
+		}
+		preparedStmtInfo.ParamTypes = stmt.GetParamsType()
+	}
+	return nil
+}
+
+// DecodeSessionStates implements SessionStatesHandler DecodeSessionStates interface.
+func (tc *TiDBContext) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
+	sessionVars := tc.Session.GetSessionVars()
+	for id, preparedStmtInfo := range sessionStates.PreparedStmts {
+		// Set the next id and currentDB manually.
+		sessionVars.SetNextPreparedStmtID(id - 1)
+		sessionVars.CurrentDB = preparedStmtInfo.StmtDB
+		if preparedStmtInfo.Name == "" {
+			// Binary protocol: add to sessionVars.PreparedStmts and TiDBContext.stmts.
+			if _, _, _, err = tc.Prepare(preparedStmtInfo.StmtText); err != nil {
+				return
+			}
+		} else {
+			// Text protocol: add to sessionVars.PreparedStmts and sessionVars.PreparedStmtNameToID.
+			stmtText := strings.ReplaceAll(preparedStmtInfo.StmtText, "\\", "\\\\")
+			stmtText = strings.ReplaceAll(stmtText, "'", "\\'")
+			sql := fmt.Sprintf("prepare %s from '%s'", preparedStmtInfo.Name, stmtText)
+			stmts, err := tc.Parse(ctx, sql)
+			if err != nil {
+				return err
+			}
+			if _, err = tc.ExecuteStmt(ctx, stmts[0]); err != nil {
+				return err
+			}
+		}
+	}
+	return
 }
 
 type tidbResultSet struct {

--- a/server/mock_conn.go
+++ b/server/mock_conn.go
@@ -92,6 +92,7 @@ func CreateMockConn(t *testing.T, store kv.Storage, server *Server) MockConn {
 		Session: se,
 		stmts:   make(map[int]*TiDBStatement),
 	}
+	se.SetPreparedStmtsStatesHandler(tc)
 
 	cc := &clientConn{
 		server:     server,

--- a/session/session.go
+++ b/session/session.go
@@ -145,6 +145,8 @@ type Session interface {
 	// ExecutePreparedStmt executes a prepared statement.
 	ExecutePreparedStmt(ctx context.Context, stmtID uint32, param []types.Datum) (sqlexec.RecordSet, error)
 	DropPreparedStmt(stmtID uint32) error
+	// SetPreparedStmtsStatesHandler sets preparedStmtsStatesHandler.
+	SetPreparedStmtsStatesHandler(handler session_states.SessionStatesHandler)
 	SetClientCapability(uint32) // Set client capability flags.
 	SetConnectionID(uint64)
 	SetCommandValue(byte)
@@ -169,9 +171,6 @@ type Session interface {
 	SetDiskFullOpt(level kvrpcpb.DiskFullOpt)
 	GetDiskFullOpt() kvrpcpb.DiskFullOpt
 	ClearDiskFullOpt()
-
-	EncodeSessionStates() ([]byte, error)
-	DecodeSessionStates([]byte) error
 }
 
 var _ Session = (*session)(nil)
@@ -242,6 +241,9 @@ type session struct {
 	}
 	// allowed when tikv disk full happened.
 	diskFullOpt kvrpcpb.DiskFullOpt
+
+	// Used to encode and decode the states of prepared statements
+	preparedStmtsStatesHandler session_states.SessionStatesHandler
 
 	// StmtStats is used to count various indicators of each SQL in this session
 	// at each point in time. These data will be periodically taken away by the
@@ -2656,6 +2658,10 @@ func (s *session) RefreshVars(ctx context.Context) error {
 	return nil
 }
 
+func (s *session) SetPreparedStmtsStatesHandler(handler session_states.SessionStatesHandler) {
+	s.preparedStmtsStatesHandler = handler
+}
+
 // CreateSession4Test creates a new session environment for test.
 func CreateSession4Test(store kv.Storage) (Session, error) {
 	return CreateSession4TestWithOpt(store, nil)
@@ -3443,35 +3449,31 @@ func (s *session) GetStmtStats() *stmtstats.StatementStats {
 	return s.stmtStats
 }
 
-func (s *session) EncodeSessionStates() ([]byte, error) {
+func (s *session) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
 	s.txn.mu.Lock()
-	if s.txn.Valid() {
-		s.txn.mu.Unlock()
-		return nil, errors.New("session is in a transaction")
-	}
+	valid := s.txn.Valid()
 	s.txn.mu.Unlock()
+	if valid {
+		return errors.New("session is in a transaction")
+	}
 
-	sessionStates := &session_states.SessionStates{}
-	err := s.sessionVars.EncodeSessionStates(sessionStates)
-	if err != nil {
-		return nil, err
+	if err = s.preparedStmtsStatesHandler.EncodeSessionStates(ctx, sessionStates); err != nil {
+		return
+	}
+	if err = s.sessionVars.EncodeSessionStates(ctx, sessionStates); err != nil {
+		return
 	}
 
 	sessionStates.LockedTables = s.lockedTables
-	result, err := json.Marshal(sessionStates)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return result, nil
+	return
 }
 
-func (s *session) DecodeSessionStates(data []byte) error {
-	var sessionStates session_states.SessionStates
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := decoder.Decode(&sessionStates); err != nil {
-		return errors.Trace(err)
+func (s *session) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
+	// Decode prepared statements first because it will affect many session states.
+	if err = s.preparedStmtsStatesHandler.DecodeSessionStates(ctx, sessionStates); err != nil {
+		return
 	}
+
 	s.lockedTables = sessionStates.LockedTables
-	return s.sessionVars.DecodeSessionStates(&sessionStates)
+	return s.sessionVars.DecodeSessionStates(ctx, sessionStates)
 }

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
@@ -43,6 +44,7 @@ type InfoschemaMetaVersion interface {
 
 // Context is an interface for transaction and executive args environment.
 type Context interface {
+	session_states.SessionStatesHandler
 	// NewTxn creates a new transaction for further execution.
 	// If old transaction is valid, it is committed first.
 	// It's used in BEGIN statement and DDL statements to commit old transaction.
@@ -148,10 +150,6 @@ type Context interface {
 	GetStmtStats() *stmtstats.StatementStats
 	// ShowProcess returns ProcessInfo running in current Context
 	ShowProcess() *util.ProcessInfo
-	// EncodeSessionStates encodes session states into a JSON.
-	EncodeSessionStates() ([]byte, error)
-	// DecodeSessionStates decodes a map into session states.
-	DecodeSessionStates([]byte) error
 }
 
 type basicCtxType int

--- a/sessionctx/session_states/session_states.go
+++ b/sessionctx/session_states/session_states.go
@@ -1,12 +1,20 @@
 package session_states
 
 import (
+	"context"
 	"time"
 
 	"github.com/pingcap/tidb/parser/model"
 	ptypes "github.com/pingcap/tidb/parser/types"
 	"github.com/pingcap/tidb/types"
 )
+
+type PreparedStmtInfo struct {
+	Name       string `json:"name,omitempty"`
+	StmtText   string `json:"text"`
+	StmtDB     string `json:"db,omitempty"`
+	ParamTypes []byte `json:"types,omitempty"`
+}
 
 type TxnIsolationLevelOneShot struct {
 	State uint   `json:"state"`
@@ -16,26 +24,33 @@ type TxnIsolationLevelOneShot struct {
 type SQLWarn struct {
 	Level   string `json:"level"`
 	Code    uint16 `json:"code"`
-	Message string `json:"message"`
+	Message string `json:"msg"`
+}
+
+type SessionStatesHandler interface {
+	// EncodeSessionStates encodes session states into a JSON.
+	EncodeSessionStates(context.Context, *SessionStates) error
+	// DecodeSessionStates decodes a map into session states.
+	DecodeSessionStates(context.Context, *SessionStates) error
 }
 
 type SessionStates struct {
-	LockedTables         map[int64]model.TableLockTpInfo `json:"locked-tables,omitempty"`
-	UserVars             map[string]types.DatumJSON      `json:"user-vars,omitempty"`
-	UserVarTypes         map[string]*ptypes.FieldType    `json:"user-var-types,omitempty"`
-	SystemVars           map[string]string               `json:"system-vars,omitempty"`
-	PreparedStmts        map[uint32]interface{}          `json:"prepared-stmts,omitempty"`
-	PreparedStmtNameToID map[string]uint32               `json:"prepared-stmt-names,omitempty"`
-	PreparedStmtID       uint32                          `json:"prepared-stmt-id,omitempty"`
-	TxnIsolationLevel    *TxnIsolationLevelOneShot       `json:"txn_iso_level,omitempty"`
-	Status               uint16                          `json:"status,omitempty"`
-	CurrentDB            string                          `json:"current-db,omitempty"`
-	LastFoundRows        uint64                          `json:"last-found-rows,omitempty"`
-	LastInsertID         uint64                          `json:"last-insert-id,omitempty"`
-	PrevAffectedRows     int64                           `json:"affected-rows,omitempty"`
-	SequenceLatestValues map[int64]int64                 `json:"sequence-values,omitempty"`
-	MPPStoreLastFailTime map[string]time.Time            `json:"store-last-fail,omitempty"`
-	Warnings             []SQLWarn                       `json:"warnings,omitempty"`
+	LockedTables map[int64]model.TableLockTpInfo `json:"locked-tables,omitempty"`
+	// TODO: advisoryLocks
+	UserVars             map[string]types.DatumJSON   `json:"user-vars,omitempty"`
+	UserVarTypes         map[string]*ptypes.FieldType `json:"user-var-types,omitempty"`
+	SystemVars           map[string]string            `json:"system-vars,omitempty"`
+	PreparedStmts        map[uint32]*PreparedStmtInfo `json:"prepared-stmts,omitempty"`
+	PreparedStmtID       uint32                       `json:"prepared-stmt-id,omitempty"`
+	TxnIsolationLevel    *TxnIsolationLevelOneShot    `json:"txn_iso_level,omitempty"`
+	Status               uint16                       `json:"status,omitempty"`
+	CurrentDB            string                       `json:"current-db,omitempty"`
+	LastFoundRows        uint64                       `json:"last-found-rows,omitempty"`
+	LastInsertID         uint64                       `json:"last-insert-id,omitempty"`
+	PrevAffectedRows     int64                        `json:"affected-rows,omitempty"`
+	SequenceLatestValues map[int64]int64              `json:"sequence-values,omitempty"`
+	MPPStoreLastFailTime map[string]time.Time         `json:"store-last-fail,omitempty"`
+	Warnings             []SQLWarn                    `json:"warnings,omitempty"`
 }
 
 func (ss *SessionStates) DecodeUserVars() (map[string]types.Datum, error) {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -16,6 +16,7 @@ package variable
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -1531,6 +1532,11 @@ func (s *SessionVars) GetNextPreparedStmtID() uint32 {
 	return s.preparedStmtID
 }
 
+// SetNextPreparedStmtID sets the next prepared statement id. It's only used in restoring session states.
+func (s *SessionVars) SetNextPreparedStmtID(preparedStmtID uint32) {
+	s.preparedStmtID = preparedStmtID
+}
+
 // Location returns the value of time_zone session variable. If it is nil, then return time.Local.
 func (s *SessionVars) Location() *time.Location {
 	loc := s.TimeZone
@@ -1685,7 +1691,7 @@ func (s *SessionVars) GetTemporaryTable(tblInfo *model.TableInfo) tableutil.Temp
 }
 
 // EncodeSessionStates saves session states into SessionStates.
-func (s *SessionVars) EncodeSessionStates(sessionStates *session_states.SessionStates) error {
+func (s *SessionVars) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
 	// Encode user-defined variables.
 	var err error
 	func() {
@@ -1742,11 +1748,13 @@ func (s *SessionVars) EncodeSessionStates(sessionStates *session_states.SessionS
 			sessionStates.SystemVars[sv.Name] = val
 		}
 	}
+
+	sessionStates.PreparedStmtID = s.preparedStmtID
 	return nil
 }
 
 // DecodeSessionStates restore session states from SessionStates.
-func (s *SessionVars) DecodeSessionStates(sessionStates *session_states.SessionStates) error {
+func (s *SessionVars) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
 	var err error
 	func() {
 		s.UsersLock.Lock()
@@ -1765,6 +1773,8 @@ func (s *SessionVars) DecodeSessionStates(sessionStates *session_states.SessionS
 			return err
 		}
 	}
+
+	s.preparedStmtID = sessionStates.PreparedStmtID
 	return nil
 }
 

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/disk"
@@ -109,12 +110,12 @@ func (c *Context) ShowProcess() *util.ProcessInfo {
 }
 
 // EncodeSessionStates implements sessionctx.Context EncodeSessionStates interface.
-func (c *Context) EncodeSessionStates() ([]byte, error) {
-	return nil, errors.Errorf("Not Supported")
+func (c *Context) EncodeSessionStates(context.Context, *session_states.SessionStates) error {
+	return errors.Errorf("Not Supported")
 }
 
 // DecodeSessionStates implements sessionctx.Context DecodeSessionStates interface.
-func (c *Context) DecodeSessionStates([]byte) error {
+func (c *Context) DecodeSessionStates(context.Context, *session_states.SessionStates) error {
 	return errors.Errorf("Not Supported")
 }
 


### PR DESCRIPTION
This PR support encoding prepared statements into JSON and decoding it back to prepared statements.

There are a few things not handled, which will be handled in the next PR:
- What will happen when currentDB / schema / user-vars / charset changes after a statement is prepared which relies on these contexts.
- Restore the statement context back because preparing statements may affect session states.

Example:
```sql
mysql> prepare stmt from "select '\\\\'";
Query OK, 0 rows affected (0.00 sec)

mysql> execute stmt;
+---+
| \ |
+---+
| \ |
+---+
1 row in set (0.00 sec)

mysql> show session_states;
+---------------------------------------------------------------------------------------------+
| Session_states                                                                              |
+---------------------------------------------------------------------------------------------+
| {"prepared-stmt-id": 1, "prepared-stmts": {"1": {"name": "stmt", "text": "select '\\\\'"}}} |
+---------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> deallocate prepare stmt;
Query OK, 0 rows affected (0.00 sec)

mysql> set session_states '{"prepared-stmt-id": 1, "prepared-stmts": {"1": {"name": "stmt", "text": "select \'\\\\\\\\\'\"}}}';
Query OK, 0 rows affected (0.00 sec)

mysql> execute stmt;
+---+
| \ |
+---+
| \ |
+---+
1 row in set (0.00 sec)
```