### PR TITLE
sessionctx: support encoding and decoding statement context

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1896,7 +1896,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.IgnoreTruncate = true
 		sc.IgnoreZeroInDate = true
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
-		if stmt.Tp == ast.ShowWarnings || stmt.Tp == ast.ShowErrors {
+		if stmt.Tp == ast.ShowWarnings || stmt.Tp == ast.ShowErrors || stmt.Tp == ast.ShowSessionStates {
 			sc.InShowWarning = true
 			sc.SetWarnings(vars.StmtCtx.GetWarnings())
 		}
@@ -1926,6 +1926,8 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.PrevAffectedRows = int64(vars.StmtCtx.AffectedRows())
 	} else if vars.StmtCtx.InSelectStmt {
 		sc.PrevAffectedRows = -1
+	} else if vars.StmtCtx.AffectedRowsSetInForce != 0 {
+		sc.PrevAffectedRows = vars.StmtCtx.AffectedRowsSetInForce
 	}
 	if globalConfig.EnableCollectExecutionInfo {
 		// In ExplainFor case, RuntimeStatsColl should not be reset for reuse,

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -535,6 +535,10 @@ func (is *LocalTemporaryTables) RemoveTable(schema, table model.CIStr) (exist bo
 	return true
 }
 
+func (is *LocalTemporaryTables) Count() int {
+	return len(is.idx2table)
+}
+
 // SchemaByTable get a table's schema name
 func (is *LocalTemporaryTables) SchemaByTable(tableInfo *model.TableInfo) (*model.DBInfo, bool) {
 	if tableInfo == nil {

--- a/session/session.go
+++ b/session/session.go
@@ -2003,7 +2003,7 @@ func runStmt(ctx context.Context, se *session, s sqlexec.Statement) (rs sqlexec.
 	// Record diagnostic information for DML statements
 	if _, ok := s.(*executor.ExecStmt).StmtNode.(ast.DMLNode); ok {
 		defer func() {
-			sessVars.LastQueryInfo = variable.QueryInfo{
+			sessVars.LastQueryInfo = session_states.QueryInfo{
 				TxnScope:    sessVars.CheckAndGetTxnScope(),
 				StartTS:     sessVars.TxnCtx.StartTS,
 				ForUpdateTS: sessVars.TxnCtx.GetForUpdateTS(),
@@ -3455,6 +3455,14 @@ func (s *session) EncodeSessionStates(ctx context.Context, sessionStates *sessio
 	s.txn.mu.Unlock()
 	if valid {
 		return errors.New("session is in a transaction")
+	}
+
+	// Check temporary tables here to avoid circle dependency.
+	if s.sessionVars.LocalTemporaryTables != nil {
+		localTempTables := s.sessionVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables)
+		if localTempTables.Count() > 0 {
+			return errors.New("session has local temporary tables")
+		}
 	}
 
 	if err = s.preparedStmtsStatesHandler.EncodeSessionStates(ctx, sessionStates); err != nil {

--- a/sessionctx/session_states/session_states.go
+++ b/sessionctx/session_states/session_states.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pingcap/tidb/parser/model"
 	ptypes "github.com/pingcap/tidb/parser/types"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -16,15 +17,18 @@ type PreparedStmtInfo struct {
 	ParamTypes []byte `json:"types,omitempty"`
 }
 
-type TxnIsolationLevelOneShot struct {
-	State uint   `json:"state"`
-	Value string `json:"value"`
+// QueryInfo represents the information of last executed query. It's used to expose information for test purpose.
+type QueryInfo struct {
+	TxnScope    string `json:"txn_scope"`
+	StartTS     uint64 `json:"start_ts"`
+	ForUpdateTS uint64 `json:"for_update_ts"`
+	ErrMsg      string `json:"error,omitempty"`
 }
 
-type SQLWarn struct {
-	Level   string `json:"level"`
-	Code    uint16 `json:"code"`
-	Message string `json:"msg"`
+// LastDDLInfo represents the information of last DDL. It's used to expose information for test purpose.
+type LastDDLInfo struct {
+	Query  string `json:"query"`
+	SeqNum uint64 `json:"seq_num"`
 }
 
 type SessionStatesHandler interface {
@@ -37,57 +41,22 @@ type SessionStatesHandler interface {
 type SessionStates struct {
 	LockedTables map[int64]model.TableLockTpInfo `json:"locked-tables,omitempty"`
 	// TODO: advisoryLocks
-	UserVars             map[string]types.DatumJSON   `json:"user-vars,omitempty"`
+	UserVars             map[string]types.Datum       `json:"user-var-values,omitempty"`
 	UserVarTypes         map[string]*ptypes.FieldType `json:"user-var-types,omitempty"`
-	SystemVars           map[string]string            `json:"system-vars,omitempty"`
+	SystemVars           map[string]string            `json:"sys-vars,omitempty"`
 	PreparedStmts        map[uint32]*PreparedStmtInfo `json:"prepared-stmts,omitempty"`
 	PreparedStmtID       uint32                       `json:"prepared-stmt-id,omitempty"`
-	TxnIsolationLevel    *TxnIsolationLevelOneShot    `json:"txn_iso_level,omitempty"`
 	Status               uint16                       `json:"status,omitempty"`
 	CurrentDB            string                       `json:"current-db,omitempty"`
-	LastFoundRows        uint64                       `json:"last-found-rows,omitempty"`
+	LastTxnInfo          string                       `json:"txn-info,omitempty"`
+	LastQueryInfo        *QueryInfo                   `json:"query-info,omitempty"`
+	LastDDLInfo          *LastDDLInfo                 `json:"ddl-info,omitempty"`
+	LastFoundRows        uint64                       `json:"found-rows,omitempty"`
 	LastInsertID         uint64                       `json:"last-insert-id,omitempty"`
-	PrevAffectedRows     int64                        `json:"affected-rows,omitempty"`
-	SequenceLatestValues map[int64]int64              `json:"sequence-values,omitempty"`
-	MPPStoreLastFailTime map[string]time.Time         `json:"store-last-fail,omitempty"`
-	Warnings             []SQLWarn                    `json:"warnings,omitempty"`
-}
-
-func (ss *SessionStates) DecodeUserVars() (map[string]types.Datum, error) {
-	result := make(map[string]types.Datum, len(ss.UserVars))
-	for name, datumJson := range ss.UserVars {
-		datum, err := types.DatumJSONToDatum(&datumJson)
-		if err != nil {
-			return nil, err
-		}
-		result[name] = *datum
-	}
-	return result, nil
-}
-
-func (ss *SessionStates) EncodeUserVars(userVars map[string]types.Datum) error {
-	ss.UserVars = make(map[string]types.DatumJSON, len(userVars))
-	for name, datum := range userVars {
-		datumJson, err := types.DatumToDatumJSON(&datum)
-		if err != nil {
-			return err
-		}
-		ss.UserVars[name] = *datumJson
-	}
-	return nil
-}
-
-func (ss *SessionStates) DecodeUserVarFields() map[string]*ptypes.FieldType {
-	result := make(map[string]*ptypes.FieldType, len(ss.UserVarTypes))
-	for name, userVar := range ss.UserVarTypes {
-		result[name] = userVar.Clone()
-	}
-	return result
-}
-
-func (ss *SessionStates) EncodeUserVarFields(userVarFields map[string]*ptypes.FieldType) {
-	ss.UserVarTypes = make(map[string]*ptypes.FieldType, len(userVarFields))
-	for name, userVar := range userVarFields {
-		ss.UserVarTypes[name] = userVar.Clone()
-	}
+	LastAffectedRows     int64                        `json:"affected-rows,omitempty"`
+	FoundInPlanCache     bool                         `json:"in-plan-cache,omitempty"`
+	FoundInBinding       bool                         `json:"in-binding,omitempty"`
+	SequenceLatestValues map[int64]int64              `json:"seq-values,omitempty"`
+	MPPStoreLastFailTime map[string]time.Time         `json:"store-fail-time,omitempty"`
+	Warnings             []stmtctx.SQLWarn            `json:"warnings,omitempty"`
 }

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -15,6 +15,9 @@
 package stmtctx
 
 import (
+	"encoding/json"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/parser/terror"
 	"math"
 	"sort"
 	"strconv"
@@ -58,6 +61,43 @@ func AllocateTaskID() uint64 {
 type SQLWarn struct {
 	Level string
 	Err   error
+}
+
+type jsonSQLWarn struct {
+	Level  string        `json:"level"`
+	SQLErr *terror.Error `json:"err,omitempty"`
+	Msg    string        `json:"msg,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (warn *SQLWarn) MarshalJSON() ([]byte, error) {
+	w := &jsonSQLWarn{
+		Level: warn.Level,
+	}
+	e := errors.Cause(warn.Err)
+	switch x := e.(type) {
+	case *terror.Error:
+		// Omit outside errors because only the most inside error matters.
+		w.SQLErr = x
+	default:
+		w.Msg = e.Error()
+	}
+	return json.Marshal(w)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (warn *SQLWarn) UnmarshalJSON(data []byte) error {
+	var w jsonSQLWarn
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	warn.Level = w.Level
+	if w.SQLErr != nil {
+		warn.Err = w.SQLErr
+	} else {
+		warn.Err = errors.New(w.Msg)
+	}
+	return nil
 }
 
 // StatementContext contains variables for a statement.
@@ -134,6 +174,8 @@ type StatementContext struct {
 	}
 	// PrevAffectedRows is the affected-rows value(DDL is 0, DML is the number of affected rows).
 	PrevAffectedRows int64
+	// AffectedRowsSetInForce is the affected rows set in a `set session_states` statement.
+	AffectedRowsSetInForce int64
 	// PrevLastInsertID is the last insert ID of previous statement.
 	PrevLastInsertID uint64
 	// LastInsertID is the auto-generated ID in the current statement.
@@ -398,6 +440,13 @@ func (sc *StatementContext) AddAffectedRows(rows uint64) {
 	sc.mu.affectedRows += rows
 }
 
+// SetAffectedRows sets affected rows.
+func (sc *StatementContext) SetAffectedRows(rows uint64) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.affectedRows = rows
+}
+
 // AffectedRows gets affected rows.
 func (sc *StatementContext) AffectedRows() uint64 {
 	sc.mu.Lock()
@@ -550,6 +599,7 @@ func (sc *StatementContext) SetWarnings(warns []SQLWarn) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.mu.warnings = warns
+	sc.mu.errorCount = 0
 	for _, w := range warns {
 		if w.Level == WarnLevelError {
 			sc.mu.errorCount++

--- a/sessionctx/variable/sequence_state.go
+++ b/sessionctx/variable/sequence_state.go
@@ -50,3 +50,23 @@ func (ss *SequenceState) GetLastValue(sequenceID int64) (int64, bool, error) {
 	}
 	return 0, true, nil
 }
+
+// GetAllStates returns a copied latestValueMap.
+func (ss *SequenceState) GetAllStates() map[int64]int64 {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	latestValueMap := make(map[int64]int64, len(ss.latestValueMap))
+	for seqID, latestValue := range ss.latestValueMap {
+		latestValueMap[seqID] = latestValue
+	}
+	return latestValueMap
+}
+
+// SetAllStates sets latestValueMap as a whole.
+func (ss *SequenceState) SetAllStates(latestValueMap map[int64]int64) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	for seqID, latestValue := range latestValueMap {
+		ss.latestValueMap[seqID] = latestValue
+	}
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
+	ptypes "github.com/pingcap/tidb/parser/types"
 	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	pumpcli "github.com/pingcap/tidb/tidb-binlog/pump_client"
@@ -921,10 +922,10 @@ type SessionVars struct {
 	LastTxnInfo string
 
 	// LastQueryInfo keeps track the info of last query.
-	LastQueryInfo QueryInfo
+	LastQueryInfo session_states.QueryInfo
 
 	// LastDDLInfo keeps track the info of last DDL.
-	LastDDLInfo LastDDLInfo
+	LastDDLInfo session_states.LastDDLInfo
 
 	// PartitionPruneMode indicates how and when to prune partitions.
 	PartitionPruneMode atomic2.String
@@ -1691,16 +1692,19 @@ func (s *SessionVars) GetTemporaryTable(tblInfo *model.TableInfo) tableutil.Temp
 }
 
 // EncodeSessionStates saves session states into SessionStates.
-func (s *SessionVars) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
+func (s *SessionVars) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
 	// Encode user-defined variables.
-	var err error
 	func() {
 		s.UsersLock.RLock()
 		defer s.UsersLock.RUnlock()
-		if err = sessionStates.EncodeUserVars(s.Users); err != nil {
-			return
+		sessionStates.UserVars = make(map[string]types.Datum, len(s.Users))
+		for name, userVar := range s.Users {
+			sessionStates.UserVars[name] = userVar
 		}
-		sessionStates.EncodeUserVarFields(s.UserVarTypes)
+		sessionStates.UserVarTypes = make(map[string]*ptypes.FieldType, len(s.UserVarTypes))
+		for name, userVarType := range s.UserVarTypes {
+			sessionStates.UserVarTypes[name] = userVarType.Clone()
+		}
 	}()
 	if err != nil {
 		return err
@@ -1750,19 +1754,41 @@ func (s *SessionVars) EncodeSessionStates(ctx context.Context, sessionStates *se
 	}
 
 	sessionStates.PreparedStmtID = s.preparedStmtID
-	return nil
+	sessionStates.Status = s.Status
+	sessionStates.CurrentDB = s.CurrentDB
+	sessionStates.LastTxnInfo = s.LastTxnInfo
+	if s.LastQueryInfo.StartTS != 0 {
+		sessionStates.LastQueryInfo = &s.LastQueryInfo
+	}
+	if s.LastDDLInfo.SeqNum != 0 {
+		sessionStates.LastDDLInfo = &s.LastDDLInfo
+	}
+	sessionStates.LastFoundRows = s.LastFoundRows
+	sessionStates.SequenceLatestValues = s.SequenceState.GetAllStates()
+	sessionStates.MPPStoreLastFailTime = s.MPPStoreLastFailTime
+	sessionStates.FoundInPlanCache = s.PrevFoundInPlanCache
+	sessionStates.FoundInBinding = s.PrevFoundInBinding
+
+	// Encode StatementContext. We encode it here to avoid circle dependency.
+	sessionStates.LastAffectedRows = s.StmtCtx.PrevAffectedRows
+	sessionStates.LastInsertID = s.StmtCtx.PrevLastInsertID
+	sessionStates.Warnings = s.StmtCtx.GetWarnings()
+	return err
 }
 
-// DecodeSessionStates restore session states from SessionStates.
-func (s *SessionVars) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
-	var err error
+// DecodeSessionStates restores session states from SessionStates.
+func (s *SessionVars) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
 	func() {
 		s.UsersLock.Lock()
 		defer s.UsersLock.Unlock()
-		if s.Users, err = sessionStates.DecodeUserVars(); err != nil {
-			return
+		s.Users = make(map[string]types.Datum, len(sessionStates.UserVars))
+		for name, userVar := range sessionStates.UserVars {
+			s.Users[name] = userVar
 		}
-		s.UserVarTypes = sessionStates.DecodeUserVarFields()
+		s.UserVarTypes = make(map[string]*ptypes.FieldType, len(sessionStates.UserVarTypes))
+		for name, userVarType := range sessionStates.UserVarTypes {
+			s.UserVarTypes[name] = userVarType.Clone()
+		}
 	}()
 	if err != nil {
 		return err
@@ -1775,7 +1801,31 @@ func (s *SessionVars) DecodeSessionStates(ctx context.Context, sessionStates *se
 	}
 
 	s.preparedStmtID = sessionStates.PreparedStmtID
-	return nil
+	s.Status = sessionStates.Status
+	s.CurrentDB = sessionStates.CurrentDB
+	s.LastTxnInfo = sessionStates.LastTxnInfo
+	if sessionStates.LastQueryInfo != nil {
+		s.LastQueryInfo = *sessionStates.LastQueryInfo
+	}
+	if sessionStates.LastDDLInfo != nil {
+		s.LastDDLInfo = *sessionStates.LastDDLInfo
+	}
+	s.LastFoundRows = sessionStates.LastFoundRows
+	s.SequenceState.SetAllStates(sessionStates.SequenceLatestValues)
+	if sessionStates.MPPStoreLastFailTime != nil {
+		s.MPPStoreLastFailTime = sessionStates.MPPStoreLastFailTime
+	}
+	s.FoundInPlanCache = sessionStates.FoundInPlanCache
+	s.FoundInBinding = sessionStates.FoundInBinding
+
+	// Decode StatementContext.
+	if sessionStates.LastAffectedRows > 0 {
+		s.StmtCtx.SetAffectedRows(uint64(sessionStates.LastAffectedRows))
+	}
+	s.StmtCtx.AffectedRowsSetInForce = sessionStates.LastAffectedRows
+	s.StmtCtx.PrevLastInsertID = sessionStates.LastInsertID
+	s.StmtCtx.SetWarnings(sessionStates.Warnings)
+	return err
 }
 
 // TableDelta stands for the changed count for one table or partition.
@@ -2352,20 +2402,6 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 // writeSlowLogItem writes a slow log item in the form of: "# ${key}:${value}"
 func writeSlowLogItem(buf *bytes.Buffer, key, value string) {
 	buf.WriteString(SlowLogRowPrefixStr + key + SlowLogSpaceMarkStr + value + "\n")
-}
-
-// QueryInfo represents the information of last executed query. It's used to expose information for test purpose.
-type QueryInfo struct {
-	TxnScope    string `json:"txn_scope"`
-	StartTS     uint64 `json:"start_ts"`
-	ForUpdateTS uint64 `json:"for_update_ts"`
-	ErrMsg      string `json:"error,omitempty"`
-}
-
-// LastDDLInfo represents the information of last DDL. It's used to expose information for test purpose.
-type LastDDLInfo struct {
-	Query  string `json:"query"`
-	SeqNum uint64 `json:"seq_num"`
 }
 
 // TxnReadTS indicates the value and used situation for tx_read_ts

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -180,6 +180,8 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: ScopeSession, Name: TxnIsolationOneShot, Value: "", skipInit: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		return checkIsolationLevel(vars, normalizedValue, originalValue, scope)
+	}, GetSession: func(s *SessionVars) (string, error) {
+		return s.txnIsolationLevelOneShot.value, nil
 	}, SetSession: func(s *SessionVars, val string) error {
 		s.txnIsolationLevelOneShot.state = oneShotSet
 		s.txnIsolationLevelOneShot.value = val

--- a/types/datum.go
+++ b/types/datum.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	gjson "encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -1998,6 +1999,77 @@ func (d *Datum) ToMysqlJSON() (j json.BinaryJSON, err error) {
 	return
 }
 
+type jsonDatum struct {
+	K         byte      `json:"k"`
+	Decimal   uint16    `json:"decimal,omitempty"`
+	Length    uint32    `json:"length,omitempty"`
+	I         int64     `json:"i,omitempty"`
+	Collation string    `json:"collation,omitempty"`
+	B         []byte    `json:"b,omitempty"`
+	Duration  *Duration `json:"d,omitempty"`
+	U         uint64    `json:"u,omitempty"`
+	F         float64   `json:"f,omitempty"`
+}
+
+func (d *Datum) MarshalJSON() ([]byte, error) {
+	jd := &jsonDatum{
+		K:         d.k,
+		Decimal:   d.decimal,
+		Length:    d.length,
+		I:         d.i,
+		Collation: d.collation,
+		B:         d.b,
+	}
+	var err error
+	switch d.k {
+	case KindMysqlTime:
+		jd.U, err = d.GetMysqlTime().ToPackedUint()
+	case KindMysqlDecimal:
+		jd.F, err = d.GetMysqlDecimal().ToFloat64()
+	case KindMysqlDuration:
+		d := d.GetMysqlDuration()
+		jd.Duration = &d
+	default:
+		if d.x != nil {
+			return nil, errors.New(fmt.Sprintf("unsupported type: %d", d.k))
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return gjson.Marshal(jd)
+}
+
+func (d *Datum) UnmarshalJSON(data []byte) error {
+	var jd jsonDatum
+	var err error
+	if err = gjson.Unmarshal(data, &jd); err != nil {
+		return err
+	}
+	d.k = jd.K
+	d.decimal = jd.Decimal
+	d.length = jd.Length
+	d.i = jd.I
+	d.collation = jd.Collation
+	d.b = jd.B
+
+	switch jd.K {
+	case KindMysqlTime:
+		var t Time
+		if err = t.FromPackedUint(jd.U); err == nil {
+			d.SetMysqlTime(t)
+		}
+	case KindMysqlDecimal:
+		var dec MyDecimal
+		if err = dec.FromFloat64(jd.F); err == nil {
+			d.SetMysqlDecimal(&dec)
+		}
+	case KindMysqlDuration:
+		d.SetMysqlDuration(*jd.Duration)
+	}
+	return err
+}
+
 func invalidConv(d *Datum, tp byte) (Datum, error) {
 	return Datum{}, errors.Errorf("cannot convert datum from %s to type %s", KindStr(d.Kind()), TypeStr(tp))
 }
@@ -2415,69 +2487,4 @@ func EstimatedMemUsage(array []Datum, numOfRows int) int64 {
 	}
 	bytesConsumed += len(array) * sizeOfEmptyDatum
 	return int64(bytesConsumed * numOfRows)
-}
-
-type DatumJSON struct {
-	K         byte      `json:"k"`
-	Decimal   uint16    `json:"decimal,omitempty"`
-	Length    uint32    `json:"length,omitempty"`
-	I         int64     `json:"i,omitempty"`
-	Collation string    `json:"collation,omitempty"`
-	B         []byte    `json:"b,omitempty"`
-	Duration  *Duration `json:"d,omitempty"`
-	U         uint64    `json:"u,omitempty"`
-	F         float64   `json:"f,omitempty"`
-}
-
-func DatumToDatumJSON(datum *Datum) (*DatumJSON, error) {
-	datumJson := &DatumJSON{
-		K:         datum.k,
-		Decimal:   datum.decimal,
-		Length:    datum.length,
-		I:         datum.i,
-		Collation: datum.collation,
-		B:         datum.b,
-	}
-	var err error
-	switch datum.k {
-	case KindMysqlTime:
-		datumJson.U, err = datum.GetMysqlTime().ToPackedUint()
-	case KindMysqlDecimal:
-		datumJson.F, err = datum.GetMysqlDecimal().ToFloat64()
-	case KindMysqlDuration:
-		d := datum.GetMysqlDuration()
-		datumJson.Duration = &d
-	default:
-		if datum.x != nil {
-			return nil, errors.New(fmt.Sprintf("unsupported type: %d", datum.k))
-		}
-	}
-	return datumJson, err
-}
-
-func DatumJSONToDatum(datumJson *DatumJSON) (*Datum, error) {
-	datum := &Datum{
-		k:         datumJson.K,
-		decimal:   datumJson.Decimal,
-		length:    datumJson.Length,
-		i:         datumJson.I,
-		collation: datumJson.Collation,
-		b:         datumJson.B,
-	}
-	var err error
-	switch datumJson.K {
-	case KindMysqlTime:
-		var t Time
-		if err = t.FromPackedUint(datumJson.U); err == nil {
-			datum.SetMysqlTime(t)
-		}
-	case KindMysqlDecimal:
-		var d MyDecimal
-		if err = d.FromFloat64(datumJson.F); err == nil {
-			datum.SetMysqlDecimal(&d)
-		}
-	case KindMysqlDuration:
-		datum.SetMysqlDuration(*datumJson.Duration)
-	}
-	return datum, err
 }


### PR DESCRIPTION
This PR encodes statement context into JSON and decodes it.

These states include:
```go
	LastTxnInfo          string                       `json:"txn-info,omitempty"`
	LastQueryInfo        *QueryInfo                   `json:"query-info,omitempty"`
	LastDDLInfo          *LastDDLInfo                 `json:"ddl-info,omitempty"`
	LastFoundRows        uint64                       `json:"found-rows,omitempty"`
	LastInsertID         uint64                       `json:"last-insert-id,omitempty"`
	LastAffectedRows     int64                        `json:"affected-rows,omitempty"`
	FoundInPlanCache     bool                         `json:"in-plan-cache,omitempty"`
	FoundInBinding       bool                         `json:"in-binding,omitempty"`
	SequenceLatestValues map[int64]int64              `json:"seq-values,omitempty"`
	MPPStoreLastFailTime map[string]time.Time         `json:"store-fail-time,omitempty"`
	Warnings             []stmtctx.SQLWarn            `json:"warnings,omitempty"`
```

Example:
```sql
mysql> set session_states '{"affected-rows": 100, "current-db": "test", "found-rows": 200, "last-insert-id": 300}';
Query OK, 100 rows affected (0.00 sec)

mysql> select row_count(), database(), found_rows(), last_insert_id();
+-------------+------------+--------------+------------------+
| row_count() | database() | found_rows() | last_insert_id() |
+-------------+------------+--------------+------------------+
|         100 | test       |          200 |              300 |
+-------------+------------+--------------+------------------+
1 row in set (0.01 sec)

mysql> set session_states '{"warnings": [{"err": {"class": 17, "code": 1287, "message": "\'tidb_index_lookup_concurrency\' is deprecated and will be removed in a future release. Please use tidb_executor_concurrency instead", "rfccode": "variable:1287"}, "level": "Warning"}]}';
Query OK, 0 rows affected, 1 warning (0.00 sec)

mysql> show warnings;
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                             |
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1287 | 'tidb_index_lookup_concurrency' is deprecated and will be removed in a future release. Please use tidb_executor_concurrency instead |
+---------+------+-------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> set session_states '{"ddl-info": {"query": "create sequence seq", "seq_num": 38}, "seq-values": {"73": 1}}';
Query OK, 0 rows affected (0.00 sec)

mysql> select lastval(seq), @@tidb_last_ddl_info;
+--------------+----------------------------------------------+
| lastval(seq) | @@tidb_last_ddl_info                         |
+--------------+----------------------------------------------+
|            1 | {"query":"create sequence seq","seq_num":38} |
+--------------+----------------------------------------------+
1 row in set (0.00 sec)
```