### PR TITLE
server: fix the server doesn't know `AuthTiDBSessionToken`

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -730,6 +730,7 @@ func (cc *clientConn) handleAuthPlugin(ctx context.Context, resp *handshakeRespo
 		case mysql.AuthCachingSha2Password:
 		case mysql.AuthNativePassword:
 		case mysql.AuthSocket:
+		case mysql.AuthTiDBSessionToken:
 		default:
 			logutil.Logger(ctx).Warn("Unknown Auth Plugin", zap.String("plugin", resp.AuthPlugin))
 		}


### PR DESCRIPTION
In some cases, the server may report AuthTiDBSessionToken as an unknown auth plugin. This PR fixes it.