### PR TITLE
server: fix paramTypes is not restored

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -338,9 +338,12 @@ func (tc *TiDBContext) DecodeSessionStates(ctx context.Context, sessionStates *s
 		sessionVars.CurrentDB = preparedStmtInfo.StmtDB
 		if preparedStmtInfo.Name == "" {
 			// Binary protocol: add to sessionVars.PreparedStmts and TiDBContext.stmts.
-			if _, _, _, err = tc.Prepare(preparedStmtInfo.StmtText); err != nil {
+			var stmt PreparedStatement
+			if stmt, _, _, err = tc.Prepare(preparedStmtInfo.StmtText); err != nil {
 				return
 			}
+			// Only binary protocol uses paramsType, which is passed from the first COM_STMT_EXECUTE.
+			stmt.SetParamsType(preparedStmtInfo.ParamTypes)
 		} else {
 			// Text protocol: add to sessionVars.PreparedStmts and sessionVars.PreparedStmtNameToID.
 			stmtText := strings.ReplaceAll(preparedStmtInfo.StmtText, "\\", "\\\\")


### PR DESCRIPTION
`ParamTypes` stands for the types of params in binary-protocol prepared statements. They are passed from the first `COM_STMT_EXECUTE`. The previous PR encodes them but forgot to restore them.

Manual test:
```
// start a sysbench to connect to the weir proxy
sysbench oltp_point_select --table_size=100000 --mysql-user=root --threads=1 --time=300 --report-interval=10 --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=sbtest  run

// redirect connections with weir
curl -X POST http://127.0.0.1:6001/test/redirect

// the sysbench still runs
[ 10s ] thds: 1 tps: 4330.30 qps: 4330.30 (r/w/o: 4330.30/0.00/0.00) lat (ms,95%): 0.25 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 1 tps: 7395.74 qps: 7395.74 (r/w/o: 7395.74/0.00/0.00) lat (ms,95%): 0.17 err/s: 0.00 reconn/s: 0.00
```