### PR TITLE
sessionctx: fix user vars are not restored

### DIFF
--- a/sessionctx/session_states/session_states.go
+++ b/sessionctx/session_states/session_states.go
@@ -41,7 +41,7 @@ type SessionStatesHandler interface {
 type SessionStates struct {
 	LockedTables map[int64]model.TableLockTpInfo `json:"locked-tables,omitempty"`
 	// TODO: advisoryLocks
-	UserVars             map[string]types.Datum       `json:"user-var-values,omitempty"`
+	UserVars             map[string]*types.Datum      `json:"user-var-values,omitempty"`
 	UserVarTypes         map[string]*ptypes.FieldType `json:"user-var-types,omitempty"`
 	SystemVars           map[string]string            `json:"sys-vars,omitempty"`
 	PreparedStmts        map[uint32]*PreparedStmtInfo `json:"prepared-stmts,omitempty"`

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -16,8 +16,6 @@ package stmtctx
 
 import (
 	"encoding/json"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/parser/terror"
 	"math"
 	"sort"
 	"strconv"
@@ -25,10 +23,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1697,9 +1697,9 @@ func (s *SessionVars) EncodeSessionStates(ctx context.Context, sessionStates *se
 	func() {
 		s.UsersLock.RLock()
 		defer s.UsersLock.RUnlock()
-		sessionStates.UserVars = make(map[string]types.Datum, len(s.Users))
+		sessionStates.UserVars = make(map[string]*types.Datum, len(s.Users))
 		for name, userVar := range s.Users {
-			sessionStates.UserVars[name] = userVar
+			sessionStates.UserVars[name] = &userVar
 		}
 		sessionStates.UserVarTypes = make(map[string]*ptypes.FieldType, len(s.UserVarTypes))
 		for name, userVarType := range s.UserVarTypes {
@@ -1783,7 +1783,7 @@ func (s *SessionVars) DecodeSessionStates(ctx context.Context, sessionStates *se
 		defer s.UsersLock.Unlock()
 		s.Users = make(map[string]types.Datum, len(sessionStates.UserVars))
 		for name, userVar := range sessionStates.UserVars {
-			s.Users[name] = userVar
+			s.Users[name] = *userVar
 		}
 		s.UserVarTypes = make(map[string]*ptypes.FieldType, len(sessionStates.UserVarTypes))
 		for name, userVarType := range sessionStates.UserVarTypes {


### PR DESCRIPTION
The `SessionStates.UserVars` was `map[string]types.Datum` and `json.Marshal(sessionStates)` won't call `Datum.MarshalJSON()`, which results in empty bytes.
The type of `SessionStates.UserVars` should be `map[string]*types.Datum`.