### PR TITLE
sessionctx, bindinfo: support encoding and decoding sql bindings

### DIFF
--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -15,6 +15,7 @@
 package bindinfo
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
@@ -102,6 +104,61 @@ func (h *SessionHandle) GetBindRecord(hash, normdOrigSQL, db string) *BindRecord
 // GetAllBindRecord return all session bind info.
 func (h *SessionHandle) GetAllBindRecord() (bindRecords []*BindRecord) {
 	return h.ch.GetAllBindRecords()
+}
+
+func (h *SessionHandle) EncodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) error {
+	bindRecords := h.ch.GetAllBindRecords()
+	if len(bindRecords) == 0 {
+		return nil
+	}
+	clonedBindRecords := make([]*session_states.BindRecord, 0, len(bindRecords))
+	for _, bindRecord := range bindRecords {
+		clonedBindings := make([]session_states.Binding, 0, len(bindRecord.Bindings))
+		for _, binding := range bindRecord.Bindings {
+			clonedBindings = append(clonedBindings, session_states.Binding{
+				BindSQL:    binding.BindSQL,
+				Status:     binding.Status,
+				CreateTime: binding.CreateTime,
+				UpdateTime: binding.UpdateTime,
+				Source:     binding.Source,
+				Charset:    binding.Charset,
+				Collation:  binding.Collation,
+			})
+		}
+		clonedBindRecords = append(clonedBindRecords, &session_states.BindRecord{
+			OriginalSQL: bindRecord.OriginalSQL,
+			Db:          bindRecord.Db,
+			Bindings:    clonedBindings,
+		})
+	}
+	sessionStates.Bindings = clonedBindRecords
+	return nil
+}
+
+func (h *SessionHandle) DecodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) error {
+	for _, clonedBindRecords := range sessionStates.Bindings {
+		for _, clonedBinding := range clonedBindRecords.Bindings {
+			binding := Binding{
+				BindSQL:    clonedBinding.BindSQL,
+				Status:     clonedBinding.Status,
+				CreateTime: clonedBinding.CreateTime,
+				UpdateTime: clonedBinding.UpdateTime,
+				Source:     clonedBinding.Source,
+				Charset:    clonedBinding.Charset,
+				Collation:  clonedBinding.Collation,
+			}
+			record := &BindRecord{
+				OriginalSQL: clonedBindRecords.OriginalSQL,
+				Db:          clonedBindRecords.Db,
+				Bindings:    []Binding{binding},
+			}
+			if err := record.prepareHints(sctx); err != nil {
+				return err
+			}
+			h.appendBindRecord(parser.DigestNormalized(record.OriginalSQL).String(), record)
+		}
+	}
+	return nil
 }
 
 // Close closes the session handle.

--- a/executor/show.go
+++ b/executor/show.go
@@ -1896,7 +1896,7 @@ func (e *ShowExec) fetchShowBuiltins() error {
 
 func (e *ShowExec) fetchShowSessionStates(ctx context.Context) error {
 	sessionStates := &session_states.SessionStates{}
-	err := e.ctx.EncodeSessionStates(ctx, sessionStates)
+	err := e.ctx.EncodeSessionStates(ctx, e.ctx, sessionStates)
 	if err != nil {
 		return err
 	}

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1667,7 +1667,7 @@ func (e *SimpleExec) executeSetSessionStates(ctx context.Context, s *ast.SetSess
 	if err := decoder.Decode(&sessionStates); err != nil {
 		return errors.Trace(err)
 	}
-	return e.ctx.DecodeSessionStates(ctx, &sessionStates)
+	return e.ctx.DecodeSessionStates(ctx, e.ctx, &sessionStates)
 }
 
 func (e *SimpleExec) executeAdmin(s *ast.AdminStmt) error {

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/pingcap/tidb/sessionctx/session_states"
 	"strings"
 	"sync/atomic"
 
@@ -30,6 +29,8 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -202,7 +203,7 @@ func (qd *TiDBDriver) OpenCtx(connID uint64, capability uint32, collation uint8,
 		Session: se,
 		stmts:   make(map[int]*TiDBStatement),
 	}
-	se.SetPreparedStmtsStatesHandler(tc)
+	se.SetSessionStatesHandler(session_states.StatePrepareStmt, tc)
 	return tc, nil
 }
 
@@ -298,7 +299,7 @@ func (tc *TiDBContext) GetStmtStats() *stmtstats.StatementStats {
 }
 
 // EncodeSessionStates implements SessionStatesHandler EncodeSessionStates interface.
-func (tc *TiDBContext) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) error {
+func (tc *TiDBContext) EncodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) error {
 	sessionVars := tc.Session.GetSessionVars()
 	sessionStates.PreparedStmts = make(map[uint32]*session_states.PreparedStmtInfo, len(sessionVars.PreparedStmts))
 	for preparedID, preparedObj := range sessionVars.PreparedStmts {
@@ -330,7 +331,7 @@ func (tc *TiDBContext) EncodeSessionStates(ctx context.Context, sessionStates *s
 }
 
 // DecodeSessionStates implements SessionStatesHandler DecodeSessionStates interface.
-func (tc *TiDBContext) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
+func (tc *TiDBContext) DecodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) (err error) {
 	sessionVars := tc.Session.GetSessionVars()
 	for id, preparedStmtInfo := range sessionStates.PreparedStmts {
 		// Set the next id and currentDB manually.

--- a/server/mock_conn.go
+++ b/server/mock_conn.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx/session_states"
 	"github.com/pingcap/tidb/util/arena"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,7 @@ func CreateMockConn(t *testing.T, store kv.Storage, server *Server) MockConn {
 		Session: se,
 		stmts:   make(map[int]*TiDBStatement),
 	}
-	se.SetPreparedStmtsStatesHandler(tc)
+	se.SetSessionStatesHandler(session_states.StatePrepareStmt, tc)
 
 	cc := &clientConn{
 		server:     server,

--- a/session/session.go
+++ b/session/session.go
@@ -145,8 +145,8 @@ type Session interface {
 	// ExecutePreparedStmt executes a prepared statement.
 	ExecutePreparedStmt(ctx context.Context, stmtID uint32, param []types.Datum) (sqlexec.RecordSet, error)
 	DropPreparedStmt(stmtID uint32) error
-	// SetPreparedStmtsStatesHandler sets preparedStmtsStatesHandler.
-	SetPreparedStmtsStatesHandler(handler session_states.SessionStatesHandler)
+	// SetSessionStatesHandler sets SessionStatesHandler for type stateType.
+	SetSessionStatesHandler(stateType int, handler sessionctx.SessionStatesHandler)
 	SetClientCapability(uint32) // Set client capability flags.
 	SetConnectionID(uint64)
 	SetCommandValue(byte)
@@ -242,8 +242,8 @@ type session struct {
 	// allowed when tikv disk full happened.
 	diskFullOpt kvrpcpb.DiskFullOpt
 
-	// Used to encode and decode the states of prepared statements
-	preparedStmtsStatesHandler session_states.SessionStatesHandler
+	// Used to encode and decode each type of session states.
+	sessionStatesHandlers map[int]sessionctx.SessionStatesHandler
 
 	// StmtStats is used to count various indicators of each SQL in this session
 	// at each point in time. These data will be periodically taken away by the
@@ -2658,8 +2658,8 @@ func (s *session) RefreshVars(ctx context.Context) error {
 	return nil
 }
 
-func (s *session) SetPreparedStmtsStatesHandler(handler session_states.SessionStatesHandler) {
-	s.preparedStmtsStatesHandler = handler
+func (s *session) SetSessionStatesHandler(stateType int, handler sessionctx.SessionStatesHandler) {
+	s.sessionStatesHandlers[stateType] = handler
 }
 
 // CreateSession4Test creates a new session environment for test.
@@ -2709,6 +2709,7 @@ func CreateSessionWithOpt(store kv.Storage, opt *Opt) (Session, error) {
 
 	sessionBindHandle := bindinfo.NewSessionBindHandle(parser.New())
 	s.SetValue(bindinfo.SessionBindInfoKeyType, sessionBindHandle)
+	s.SetSessionStatesHandler(session_states.StateBinding, sessionBindHandle)
 	// Add stats collector, and it will be freed by background stats worker
 	// which periodically updates stats using the collected data.
 	if do.StatsHandle() != nil && do.StatsUpdating() {
@@ -2954,12 +2955,13 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 		return nil, err
 	}
 	s := &session{
-		store:           store,
-		sessionVars:     variable.NewSessionVars(),
-		ddlOwnerChecker: dom.DDL().OwnerManager(),
-		client:          store.GetClient(),
-		mppClient:       store.GetMPPClient(),
-		stmtStats:       stmtstats.CreateStatementStats(),
+		store:                 store,
+		sessionVars:           variable.NewSessionVars(),
+		ddlOwnerChecker:       dom.DDL().OwnerManager(),
+		client:                store.GetClient(),
+		mppClient:             store.GetMPPClient(),
+		stmtStats:             stmtstats.CreateStatementStats(),
+		sessionStatesHandlers: make(map[int]sessionctx.SessionStatesHandler),
 	}
 	s.functionUsageMu.builtinFunctionUsage = make(telemetry.BuiltinFunctionsUsage)
 	if plannercore.PreparedPlanCacheEnabled() {
@@ -2989,11 +2991,12 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 // a lock context, which cause we can't call createSession directly.
 func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, error) {
 	s := &session{
-		store:       store,
-		sessionVars: variable.NewSessionVars(),
-		client:      store.GetClient(),
-		mppClient:   store.GetMPPClient(),
-		stmtStats:   stmtstats.CreateStatementStats(),
+		store:                 store,
+		sessionVars:           variable.NewSessionVars(),
+		client:                store.GetClient(),
+		mppClient:             store.GetMPPClient(),
+		stmtStats:             stmtstats.CreateStatementStats(),
+		sessionStatesHandlers: make(map[int]sessionctx.SessionStatesHandler),
 	}
 	s.functionUsageMu.builtinFunctionUsage = make(telemetry.BuiltinFunctionsUsage)
 	if plannercore.PreparedPlanCacheEnabled() {
@@ -3449,7 +3452,7 @@ func (s *session) GetStmtStats() *stmtstats.StatementStats {
 	return s.stmtStats
 }
 
-func (s *session) EncodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
+func (s *session) EncodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) (err error) {
 	s.txn.mu.Lock()
 	valid := s.txn.Valid()
 	s.txn.mu.Unlock()
@@ -3465,7 +3468,10 @@ func (s *session) EncodeSessionStates(ctx context.Context, sessionStates *sessio
 		}
 	}
 
-	if err = s.preparedStmtsStatesHandler.EncodeSessionStates(ctx, sessionStates); err != nil {
+	if err = s.sessionStatesHandlers[session_states.StatePrepareStmt].EncodeSessionStates(ctx, s, sessionStates); err != nil {
+		return
+	}
+	if err = s.sessionStatesHandlers[session_states.StateBinding].EncodeSessionStates(ctx, s, sessionStates); err != nil {
 		return
 	}
 	if err = s.sessionVars.EncodeSessionStates(ctx, sessionStates); err != nil {
@@ -3476,9 +3482,12 @@ func (s *session) EncodeSessionStates(ctx context.Context, sessionStates *sessio
 	return
 }
 
-func (s *session) DecodeSessionStates(ctx context.Context, sessionStates *session_states.SessionStates) (err error) {
+func (s *session) DecodeSessionStates(ctx context.Context, sctx sessionctx.Context, sessionStates *session_states.SessionStates) (err error) {
 	// Decode prepared statements first because it will affect many session states.
-	if err = s.preparedStmtsStatesHandler.DecodeSessionStates(ctx, sessionStates); err != nil {
+	if err = s.sessionStatesHandlers[session_states.StatePrepareStmt].DecodeSessionStates(ctx, s, sessionStates); err != nil {
+		return
+	}
+	if err = s.sessionStatesHandlers[session_states.StateBinding].DecodeSessionStates(ctx, s, sessionStates); err != nil {
 		return
 	}
 

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -42,9 +42,16 @@ type InfoschemaMetaVersion interface {
 	SchemaMetaVersion() int64
 }
 
+type SessionStatesHandler interface {
+	// EncodeSessionStates encodes session states into a JSON.
+	EncodeSessionStates(context.Context, Context, *session_states.SessionStates) error
+	// DecodeSessionStates decodes a map into session states.
+	DecodeSessionStates(context.Context, Context, *session_states.SessionStates) error
+}
+
 // Context is an interface for transaction and executive args environment.
 type Context interface {
-	session_states.SessionStatesHandler
+	SessionStatesHandler
 	// NewTxn creates a new transaction for further execution.
 	// If old transaction is valid, it is committed first.
 	// It's used in BEGIN statement and DDL statements to commit old transaction.

--- a/sessionctx/session_states/session_states.go
+++ b/sessionctx/session_states/session_states.go
@@ -1,13 +1,17 @@
 package session_states
 
 import (
-	"context"
 	"time"
 
 	"github.com/pingcap/tidb/parser/model"
 	ptypes "github.com/pingcap/tidb/parser/types"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+)
+
+const (
+	StatePrepareStmt int = iota
+	StateBinding
 )
 
 type PreparedStmtInfo struct {
@@ -31,11 +35,20 @@ type LastDDLInfo struct {
 	SeqNum uint64 `json:"seq_num"`
 }
 
-type SessionStatesHandler interface {
-	// EncodeSessionStates encodes session states into a JSON.
-	EncodeSessionStates(context.Context, *SessionStates) error
-	// DecodeSessionStates decodes a map into session states.
-	DecodeSessionStates(context.Context, *SessionStates) error
+type BindRecord struct {
+	OriginalSQL string    `json:"original_sql"`
+	Db          string    `json:"db,omitempty"`
+	Bindings    []Binding `json:"bindings"`
+}
+
+type Binding struct {
+	BindSQL    string     `json:"bind_sql"`
+	Status     string     `json:"status"`
+	CreateTime types.Time `json:"create_time"`
+	UpdateTime types.Time `json:"update_time"`
+	Source     string     `json:"source"`
+	Charset    string     `json:"charset"`
+	Collation  string     `json:"collation"`
 }
 
 type SessionStates struct {
@@ -46,6 +59,7 @@ type SessionStates struct {
 	SystemVars           map[string]string            `json:"sys-vars,omitempty"`
 	PreparedStmts        map[uint32]*PreparedStmtInfo `json:"prepared-stmts,omitempty"`
 	PreparedStmtID       uint32                       `json:"prepared-stmt-id,omitempty"`
+	Bindings             []*BindRecord                `json:"bindings,omitempty"`
 	Status               uint16                       `json:"status,omitempty"`
 	CurrentDB            string                       `json:"current-db,omitempty"`
 	LastTxnInfo          string                       `json:"txn-info,omitempty"`

--- a/types/time.go
+++ b/types/time.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -539,6 +540,14 @@ func (t Time) RoundFrac(sc *stmtctx.StatementContext, fsp int) (Time, error) {
 	}
 
 	return NewTime(nt, t.Type(), fsp), nil
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.coreTime)
+}
+
+func (t *Time) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.coreTime)
 }
 
 // GetFsp gets the fsp of a string.

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -110,12 +110,12 @@ func (c *Context) ShowProcess() *util.ProcessInfo {
 }
 
 // EncodeSessionStates implements sessionctx.Context EncodeSessionStates interface.
-func (c *Context) EncodeSessionStates(context.Context, *session_states.SessionStates) error {
+func (c *Context) EncodeSessionStates(context.Context, sessionctx.Context, *session_states.SessionStates) error {
 	return errors.Errorf("Not Supported")
 }
 
 // DecodeSessionStates implements sessionctx.Context DecodeSessionStates interface.
-func (c *Context) DecodeSessionStates(context.Context, *session_states.SessionStates) error {
+func (c *Context) DecodeSessionStates(context.Context, sessionctx.Context, *session_states.SessionStates) error {
 	return errors.Errorf("Not Supported")
 }
 


### PR DESCRIPTION
Session-scoped SQL bindings are cached in `bindinfo.SessionHandle`, which is set in `sessionctx.mu.values`. I went through all the about 20 places setting `sessionctx.mu.values`, and found that:
- Some are cleared automatically after the execution of the current statement, such as `query_string`
- Some are bound objects which cannot be set, such as domain, privilegeManager
- The SQL binding is the only one that needs to be encoded

Example:
```sql
mysql> create session binding for select * from t using select * from t use index(idx_a);
Query OK, 0 rows affected (0.07 sec)

mysql> show session bindings;
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| Original_sql               | Bind_sql                                     | Default_db | Status  | Create_time             | Update_time             | Charset | Collation   | Source |
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| select * from `test` . `t` | SELECT * FROM `test`.`t` USE INDEX (`idx_a`) | test       | enabled | 2022-05-27 17:07:54.596 | 2022-05-27 17:07:54.596 | utf8mb4 | utf8mb4_bin | manual |
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
1 row in set (0.00 sec)

# redirect connections here

mysql> show session bindings;
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| Original_sql               | Bind_sql                                     | Default_db | Status  | Create_time             | Update_time             | Charset | Collation   | Source |
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| select * from `test` . `t` | SELECT * FROM `test`.`t` USE INDEX (`idx_a`) | test       | enabled | 2022-05-27 17:07:54.596 | 2022-05-27 17:07:54.596 | utf8mb4 | utf8mb4_bin | manual |
+----------------------------+----------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
1 row in set (0.01 sec)

mysql> create session binding for select * from t using select /*+ USE_INDEX(t, idx_a) */ * from t;
Query OK, 0 rows affected (0.00 sec)

mysql> show session bindings;
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| Original_sql               | Bind_sql                                              | Default_db | Status  | Create_time             | Update_time             | Charset | Collation   | Source |
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| select * from `test` . `t` | SELECT /*+ USE_INDEX(`t` `idx_a`)*/ * FROM `test`.`t` | test       | enabled | 2022-05-27 17:09:57.673 | 2022-05-27 17:09:57.673 | utf8mb4 | utf8mb4_bin | manual |
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
1 row in set (0.00 sec)

# rediect connections here

mysql> show session bindings;
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| Original_sql               | Bind_sql                                              | Default_db | Status  | Create_time             | Update_time             | Charset | Collation   | Source |
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
| select * from `test` . `t` | SELECT /*+ USE_INDEX(`t` `idx_a`)*/ * FROM `test`.`t` | test       | enabled | 2022-05-27 17:09:57.673 | 2022-05-27 17:09:57.673 | utf8mb4 | utf8mb4_bin | manual |
+----------------------------+-------------------------------------------------------+------------+---------+-------------------------+-------------------------+---------+-------------+--------+
1 row in set (0.00 sec)
```